### PR TITLE
Revert "add mailing list popup"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,8 +1261,6 @@
 
   <!-- Template Main Javascript File -->
   <script src="js/main.js"></script>
-
-  <script type="text/javascript" src="//downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">window.dojoRequire(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us17.list-manage.com","uuid":"c9f3c71f1370a7e550caa409b","lid":"f45e751233","uniqueMethods":true}) })</script>
 </body>
 
 </html>


### PR DESCRIPTION
Reverts emileber/io-conference#5

Raisons:

![image](https://user-images.githubusercontent.com/111141/60147200-90b43e00-979a-11e9-87f1-ec4d6444ec19.png)

Le pop-up ouvre sur un timer court, et cache le contenu. Si je pèse sur le X, je ne peux plus accéder au formulaire pour la newsletter. Ma seule option pour voir le contenu _et_ m'inscrire est de m'inscrire avant de lire le contenu, ou bien d'aller trouver le bon cookie à la main pour le supprimer.

Autre bug mineur:

![image](https://user-images.githubusercontent.com/111141/60147264-c6f1bd80-979a-11e9-9c26-9a77c80b9a12.png)

Le truc qui tronque le texte trop long choke sur les trucs comme `&agrave;` et brise le texte.

Je pense que point de vue usabilité, c'est complètement dans le champ et à éviter.